### PR TITLE
Ability to set WP_DEBUG in cypress config for WordPress enviroment.

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -29,6 +29,12 @@ const start = async (userConfig, packageDir, logFile) => {
     logFile,
   );
 
+  let debug = true;
+
+  if ('wp' in userConfig && 'debug' in userConfig.wp) {
+    debug = userConfig.wp.debug;
+  }
+
   await run(
     async () => wpcli(`core config \
     --dbhost=db \
@@ -37,7 +43,7 @@ const start = async (userConfig, packageDir, logFile) => {
     --dbpass='' \
     --locale=en_US \
     --extra-php <<PHP
-  define( 'WP_DEBUG', true );
+  define( 'WP_DEBUG', ${debug} );
 PHP
 `, logFile),
     'Creating config',


### PR DESCRIPTION
Fixes #14 

Enable `WP_DEBUG` to be set in cypress config by specifying the `debug` property within `wp` object to either `true` or `false`.