### PR TITLE
Allow testing env to run on custom port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,30 @@ This may take a while as it builds and starts a new docker container. However, y
 
 Once it is running there is no need to re-start it every time you run cypress. WP Cypress will start and restore the database to it's initial state between each suite of integration tests to ensure a clean slate between tests.
 
-You can add environment variables to the `cypress.json` configuration file. You can use this to specify the version of WordPress and which plugins/themes to install. All plugins will be activated and the first theme in the list will be activated. If this file is changed, you will need to re-run `wp-cypress start` to see the changes take effect. Composer is recommended to manage plugins and themes to if they do not exist in your project directory.
+#### Config
+
+You can add environment variables to the `wp` key in the `cypress.json` configuration file. If this file is changed, you will need to re-run `wp-cypress start` to see the changes take effect.
+
+##### Config Options
+
+Name | Type |  Description | Required?
+--- | --- | --- | ---
+version | string | The WordPress version to install | required
+plugins | array  | Absolute path's to plugins to install | optional
+themes | array | Absolute path's to themes to install | optional
+timezone | string | The default timezone of the WordPress installation | optional 
+port | number | Custom port number | optional
+
+##### Example Config
 
 ###### cypress.json
 ```json
 {
-  "baseUrl": "http://localhost",
+  "baseUrl": "http://localhost:3000",
   "pageLoadTimeout": 30000,
   "wp": {
     "version": "5.4", 
+    "port": 3000,
     "plugins": [ 
       "./"
       "./absolute/path/to/plugin"
@@ -134,8 +149,6 @@ You can add environment variables to the `cypress.json` configuration file. You 
 }
 
 ```
-
-An additional plugin will be installed that contains some of the logic that drives the functionality in this package.
 
 ### Seeds
 
@@ -205,8 +218,6 @@ Command | Description | Example
 --- | --- | ---
 editPost(id) | Visit the a post's edit page | `cy.editPost(1)`
 saveCurrentPost() | If on a post's edit page, save the psot | `cy.saveCurrentPost()`
-
-
 
 ## Seeder
 

--- a/bin/configureWordPress.js
+++ b/bin/configureWordPress.js
@@ -1,12 +1,9 @@
-const fs = require('fs');
 const path = require('path');
 
 const { wpcli } = require('./utils/exec');
 const run = require('./utils/run');
 
-const configureWordPress = async (configFilePath, logFile) => {
-  const config = JSON.parse(fs.readFileSync(configFilePath, 'utf8'));
-
+const configureWordPress = async (config, logFile) => {
   if (config.timezone) {
     await run(
       async () => wpcli(`option update timezone_string ${config.timezone}`, logFile),

--- a/bin/createConfig.js
+++ b/bin/createConfig.js
@@ -36,7 +36,7 @@ services:
       - db
     build: .
     ports:
-      - 80:80
+      - ${userConfig.port || 80}:80
     volumes:
       - wp:/var/www/html ${volumes.map((x) => `
       - ${x}`).join('')}

--- a/bin/resetDB.js
+++ b/bin/resetDB.js
@@ -1,9 +1,12 @@
+const fs = require('fs');
 const shell = require('shelljs');
+
 const { wpcli } = require('./utils/exec');
 const run = require('./utils/run');
 const configureWordPress = require('./configureWordPress');
 
 const resetDB = async (packageDir, logFile) => {
+  const config = JSON.parse(fs.readFileSync(`${packageDir}/config.json`, 'utf8'));
   shell.cd(packageDir);
 
   await run(
@@ -13,9 +16,11 @@ const resetDB = async (packageDir, logFile) => {
     logFile,
   );
 
+  const url = config.port ? `http://localhost:${config.port}` : 'http://localhost';
+
   await run(
     async () => wpcli(
-      'core install --url=http://localhost --title="WP Cypress" --admin_user=admin --admin_password=password --admin_email="admin@test.com" --skip-email',
+      `core install --url=${url} --title="WP Cypress" --admin_user=admin --admin_password=password --admin_email="admin@test.com" --skip-email`,
       logFile,
     ),
     'Re-installing WordPress',
@@ -23,7 +28,7 @@ const resetDB = async (packageDir, logFile) => {
     logFile,
   );
 
-  await configureWordPress(`${packageDir}/config.json`, logFile);
+  await configureWordPress(config, logFile);
 };
 
 module.exports = resetDB;


### PR DESCRIPTION
Reference Issue: #13 

Allow the user to run the testing environment on a custom port number to avoid conflicts with anything that is currently running on port 80.