### PR TITLE
Use WordPress current_time function to return local dateTime.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "WordPress end to end testing with Cypress.io",
   "main": "lib/index.js",
   "repository": "https://github.com/bigbite/wp-cypress",

--- a/plugin/Seeder/Traits/Date.php
+++ b/plugin/Seeder/Traits/Date.php
@@ -4,7 +4,7 @@ namespace WP_Cypress\Seeder\Traits;
 
 trait Date {
 	public function now() {
-		return date( 'Y-m-d H:i:s', time() );
+		return current_time( 'Y-m-d H:i:s' );
 	}
 }
 


### PR DESCRIPTION
## Description
Use Wordpress `current_time` function to so that the returned dateTime is in the local timezone - Fixes #28 

## Change Log
* Change seeder date trait

## Screenshots/Videos
_If PR includes visual changes, please include a screenshot (or short video if applicable)._

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
