### PR TITLE
Use Composer for autoloading

### DIFF
--- a/plugin/Seeder/bootstrap.php
+++ b/plugin/Seeder/bootstrap.php
@@ -11,13 +11,5 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 require_once __DIR__ . '/utils.php';
-require_once __DIR__ . '/Seeds/SeedInterface.php';
-require_once __DIR__ . '/Seeds/Seed.php';
-require_once __DIR__ . '/Seeds/Post.php';
-require_once __DIR__ . '/Seeds/Comment.php';
-require_once __DIR__ . '/Generator.php';
-require_once __DIR__ . '/SeederInterface.php';
-require_once __DIR__ . '/Seeder.php';
-require_once __DIR__ . '/Command.php';
 
 WP_CLI::add_command( 'seed', Command::class );

--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -1,5 +1,14 @@
 {
+  "name": "bigbite/wp-cypress",
+  "description": "Modifications for a test environment with Cypress.",
+  "type": "wordpress-plugin",
+  "license": "MIT",
   "require": {
     "fzaninotto/faker": "^1.9"
+  },
+  "autoload": {
+    "psr-4": {
+      "WP_Cypress\\Seeder\\": "Seeder/"
+    }
   }
 }

--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c10bab350777d80b6ec93b084fe5276",
+    "content-hash": "699c1a8dc0462cdc1354ce9c9264962f",
     "packages": [
         {
             "name": "fzaninotto/faker",
@@ -64,5 +64,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/plugin/plugin.php
+++ b/plugin/plugin.php
@@ -10,14 +10,20 @@
 
 namespace WP_Cypress;
 
+use WP_Cypress\Seeder\Command;
+
 if ( ! defined( 'WP_CYPRESS_PLUGIN' ) ) {
 	define( 'WP_CYPRESS_PLUGIN', rtrim( plugin_dir_path( __FILE__ ), '/' ) );
 }
 
-require_once WP_CYPRESS_PLUGIN . '/vendor/autoload.php';
+if ( ! class_exists( Command::class ) && is_readable( WP_CYPRESS_PLUGIN . '/vendor/autoload.php' ) ) {
+	include WP_CYPRESS_PLUGIN . '/vendor/autoload.php';
+}
+
 require_once WP_CYPRESS_PLUGIN . '/inc/auth.php';
-require_once WP_CYPRESS_PLUGIN . '/inc/disable-tooltips.php';
 require_once WP_CYPRESS_PLUGIN . '/inc/debug.php';
+require_once WP_CYPRESS_PLUGIN . '/inc/disable-tooltips.php';
+
 require_once WP_CYPRESS_PLUGIN . '/Seeder/bootstrap.php';
 
 disable_auth();


### PR DESCRIPTION
@liamdefty this is the follow-up of #33, bringing Composer-based autoloading.

I only registered the `Seeder` namespace, supporting classes, interfaces and traits inside it, but not any file containing functions. This is just a personal preference. It can certainly be done using Composer, too, but I prefer to not have functions automatically loaded in so I can easily create mocks/stubs for unit tests.