### PR TITLE
Make wordpress locale configurable

### DIFF
--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -1,4 +1,4 @@
-const { map, isString } = require('lodash');
+const { map, isString, get } = require('lodash');
 const fs = require('fs-extra');
 const shell = require('shelljs');
 
@@ -29,13 +29,15 @@ const reset = async (packageDir, logFile, options) => {
     await copyVolumes(config.volumes, config.wpContent, logFile);
   }
 
+  const locale = get(config, ['locale'], 'en_US');
+
   await run(
     async () => wpcli(`core config \
     --dbhost=db \
     --dbname=wordpress \
     --dbuser=root \
     --dbpass='' \
-    --locale=en_US \
+    --locale=${locale} \
     --extra-php <<PHP
 define( 'FS_METHOD', 'direct' );
 

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -115,7 +115,7 @@
     },
     "locale": {
       "type": "string",
-      "pattern": "^[a-z]{2}_[A-Z]{2}$",
+      "pattern": "^[a-z]{2,3}(_[A-Z]{2})?(_[a-z0-9]{4,8})?$",
       "errorMessage": "wp.locale is invalid"
     }
   },

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -112,6 +112,11 @@
         }
       ],
       "errorMessage": "wp.wpContent has invalid properties"
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[a-z]{2}_[A-Z]{2}$",
+      "errorMessage": "wp.locale is invalid"
     }
   },
   "if": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently Wordpress is always installed in the en_US version. With this change it is now possible to determine in which locale Wordpress should be installed. This makes it easy to test non-English plugins.

To use this feature, just add a `locale` to your cypress.json. If no one provided, `en_US` is used.

```
{
    "wp": {
        "locale": "de_DE"
    }
}
```

## Change Log
* Add `locale` as new config setting


## Types of changes (_if applicable_):
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
