### PR TITLE
Adds seeder clean routines

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -14,9 +14,7 @@ const reset = require('./commands/reset');
 const softReset = require('./commands/softReset');
 const wp = require('./commands/wp');
 
-program
-  .version(version)
-  .arguments('<command>');
+program.version(version).arguments('<command>');
 
 program
   .command('start')
@@ -45,5 +43,26 @@ program
   .command('wp <command>')
   .description('Execute the WordPress CLI in the running container')
   .action((command) => wp(command, packageDir, logFile));
+
+program
+  .command('seed')
+  .description('Execute WordPress CLI seed command.')
+  .option('<seeder>', 'The name of the seeder to run.')
+  .option(
+    '-cf, --clean-first',
+    'Whether to run the clean routine before seeding.',
+  )
+  .option('-c, --clean', 'Run only the seeder clean routine.')
+  .action((options) => {
+    let cleanFlag = '';
+
+    if (options.cleanFirst) {
+      cleanFlag = '--clean-first';
+    } else if (options.clean) {
+      cleanFlag = '--clean';
+    }
+
+    wp(`seed ${options.args.join(' ')} ${cleanFlag}`, packageDir, logFile);
+  });
 
 program.parse(process.argv);

--- a/lib/cypress-support/commands.js
+++ b/lib/cypress-support/commands.js
@@ -6,14 +6,32 @@ const commands = {
     cy.exec(`node_modules/.bin/wp-cypress wp "${command}"`);
   },
 
-  seed(seed) {
-    cy.exec(`node_modules/.bin/wp-cypress wp "seed ${seed}"`);
+  seed(seeder) {
+    cy.exec(`node_modules/.bin/wp-cypress wp "seed ${seeder}"`).then((result) => {
+      cy.log(result.stdout);
+    });
+  },
+
+  seedClean(seeder) {
+    cy.exec(`node_modules/.bin/wp-cypress wp "seed ${seeder} --clean"`).then(
+      (result) => {
+        cy.log(result.stdout);
+      },
+    );
+  },
+
+  cleanThenSeed(seeder) {
+    cy.exec(
+      `node_modules/.bin/wp-cypress wp "seed ${seeder} --clean-first"`,
+    ).then((result) => {
+      cy.log(result.stdout);
+    });
   },
 
   resetWP(version = false) {
     const wpVersion = version || (Cypress.wp || {}).version || false;
-    cy.log('WP Cypress: performing teardown...');
-    cy.exec(`node_modules/.bin/wp-cypress soft-reset ${wpVersion ? `--version="${wpVersion}"` : ''}`);
+    cy.log('WP Cypress: performing full teardown...');
+    cy.exec(`node_modules/.bin/wp-cypress soft-reset ${wpVersion ? `--version='${wpVersion}'` : ''}`);
   },
 
   installTheme(name) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #47 - Adds functionality to use a seeder clean-up routine in tests and the CLI. This allows for an optional method to be added to seeders as `clean()` - this should be used for any clean/tidy routines to remove any data created by the a seeder. I've also added a `wp-cypress seed` command to shorten the manual usage which also takes advantage of the clean routines (See usage examples below).

### Usage Examples

**Command**
```sh
yarn wp-cypress seed CategoriesSeeder
yarn wp-cypress seed CategoriesSeeder --clean
yarn wp-cypress seed CategoriesSeeder --clean-first
```

**Spec**
```js
describe("Categories.", () => {
  before(() => {
    cy.cleanThenSeed("CategoriesSeeder"); // Run the cleaner then seed.
  });

  it("I can add a new category.", () => {
    cy.visitAdmin();
    cy.visit("/wp-admin/edit-tags.php?taxonomy=category");
    // ...
  });

  after(() => {
    cy.seedClean("CategoriesSeeder"); // Only clean, no seeding.
  });
});
```

**Seeder**
```php
<?php

use WP_Cypress\Seeder\Seeder;

class CategoriesSeeder extends Seeder {
	const CATEGORIES = [
		'Test',
		'New Test',
	];

	public function run() {
		foreach( self::CATEGORIES as $category ) {
			wp_insert_term( $category, 'category' );
		}
	}

	public function clean() {
		foreach( self::CATEGORIES as $category ) {
			$term = get_term_by( 'name', $category, 'category' );
			wp_delete_term( $term->term_id, 'category' );
		}
	}
}
```

## Change Log
* Adds `seedClean(<seeder>)` to `cy` methods.
* Adds `cleanThenSeed(<seeder>)` to `cy` methods.
* Adds `wp-cypress seed <seeder> [--clean] [--clean-first]` command as a shortcut to `wp-cypress wp "<command>"`

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
