### PR TITLE
Allow for manual user switching.

### DIFF
--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -46,12 +46,10 @@ if ( file_exists( __DIR__ . '/wp-cypress-config.php' ) ) {
   require_once __DIR__ . '/wp-cypress-config.php';
 }
 
-function wp_validate_auth_cookie( \\$cookie='', \\$scheme='' ) {
-  if ( file_exists ( ABSPATH . '.userid' ) ) {
+if( file_exists ( ABSPATH . '.userid' ) ) {
+  function wp_validate_auth_cookie( \\$cookie='', \\$scheme='' ) {
     return file_get_contents( ABSPATH . '.userid' );
   }
-
-  return 1;
 }
 
 PHP

--- a/lib/cypress-support/commands.js
+++ b/lib/cypress-support/commands.js
@@ -48,8 +48,33 @@ const commands = {
     cy.window().then((win) => win.wp.data.dispatch('core/editor').savePost());
   },
 
-  switchUser(user = 'admin') {
-    cy.exec(`node_modules/.bin/wp-cypress wp "wp-cypress-set-user ${user}"`);
+  switchUser(user = 'admin', password = null) {
+    if (password) {
+      cy.exec('node_modules/.bin/wp-cypress wp "wp-cypress-set-user --logout"').then(() => {
+        cy.clearCookies();
+        cy.visit('/wp-login.php?loggedout=true');
+
+        // Check if Jetpack SSO is installed, click through if so.
+        cy.get('body').then((body) => {
+          if (body.find('.jetpack-sso-toggle.wpcom').length > 0) {
+            cy.get('.jetpack-sso-toggle.wpcom').click();
+          }
+        });
+
+        cy.get('#user_login').focus().invoke('val', user);
+        cy.get('#user_pass').focus().invoke('val', password);
+        cy.get('#wp-submit').click();
+      });
+    } else {
+      cy.exec(`node_modules/.bin/wp-cypress wp "wp-cypress-set-user ${user}"`);
+    }
+  },
+
+  logout() {
+    cy.exec('node_modules/.bin/wp-cypress wp "wp-cypress-set-user --logout"').then(() => {
+      cy.clearCookies();
+      cy.visit('/wp-login.php?loggedout=true');
+    });
   },
 };
 

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -61,8 +61,19 @@ class Plugin {
 	 * @param array $args
 	 * @return void
 	 */
-	public function set_user( $args ): void {
+	public function set_user( $args, array $assoc_args ): void {
 		$user_id = 'false';
+
+		$user_id_file = ABSPATH . '.userid';
+
+		if ( isset( $assoc_args['logout'] ) ) {
+			if ( file_exists( $user_id_file ) ) {
+				unlink( $user_id_file );
+			}
+
+			WP_CLI::success( 'Current User logged out' );
+			return;
+		}
 
 		if ( 'loggedout' !== $args[0] ) {
 			$user = get_user_by( 'login', $args[0] );
@@ -71,12 +82,11 @@ class Plugin {
 				WP_CLI::error( "User {$args[0]} doesn't exits." );
 				return;
 			}
-	
+
 			$user_id = $user->ID;
 		}
 
-		file_put_contents( get_home_path() . '.userid', $user_id );
-
+		file_put_contents( $user_id_file, $user_id );
 		WP_CLI::success( 'Current User set to ' . $args[0] );
 	}
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #59 - This PR opens up a number of functions to allow for some more comprehensive user switching and authentication. `switchUser()` has been expanded upon to allow for passwords to be defined so a manual login can take place, and `logout()` is added to allow for logging out the current user. With both methods, they will first attempt to remove the `.userid` file which is used for by-passing authentication and then clear cookies before redirecting back to the login page.

In addition to changing the user `switchUser()` will perform a manual login attempt via completing the login form. This will also check for Jetpack SSO and click the login link if found. This happens by providing a second parameter on `switchUser()` of a password. If a password is used then a login attempt will be made.

## Usage Example

**Spec**
```js
describe("Posts.", () => {
  it("I can add a new post as an author.", () => {
    cy.switchUser('author', 'password');
    cy.visit("/wp-admin/new-post.php");
    // ...
    cy.logout();
  });
});

```

## Change Log
* Add `--logout` flag to `wp-cypress-set-user` to remove `.userid` file (logout).
* Change `wp_validate_auth_cookie` so only defined if `.userid` file exists.
* Remove fallback user id of `1` from `wp_validate_auth_cookie`.
* Add additional/optional `password` parameter to `switchUser()` method.
* Add manual login process to `switchUser()` routine when `password` is defined.
* Add `logout()` method for strictly logging out.
 
## Screenshots/Videos
_If PR includes visual changes, please include a screenshot (or short video if applicable)._

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
