### PR TITLE
Check for docker service/daemon before running wp-cypress setup.

### DIFF
--- a/lib/cli/commands/start.js
+++ b/lib/cli/commands/start.js
@@ -14,6 +14,13 @@ const reset = require('./reset');
 const start = async (packageDir, options, logFile) => {
   const config = await createConfig(packageDir, options.volumes);
 
+  await run(
+    async () => exec('docker ps -q', logFile),
+    'Checking for Docker',
+    'Docker found',
+    logFile,
+  );
+
   if (config.wpContent) {
     shell.rm('-rf', `${config.wpContent.path}/plugins/wp-cypress`);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #53 - When Docker Desktop is quit the background service daemon is expected to also be close by the app. When running the `wp-cypress start` command, this was not checked and the build would seem like it continues as normal. This PR explicitly checks for the daemon being active utilising [`docker ps` in quiet mode (`-q`) ](https://docs.docker.com/engine/reference/commandline/ps/) which reports back a failure if the daemon is not running, otherwise it responds normal if it is running.

## Change Log
* Adds command to check for docker daemon at start of `wp-cypress start` command.

## Screenshots/Videos
_If PR includes visual changes, please include a screenshot (or short video if applicable)._

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
