### PR TITLE
Allow php version to be configurable via cypress.json

### DIFF
--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -137,6 +137,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       isWpContent: config.wpContent,
       versions: validVersions,
       vip: config.muPlugins ? config.muPlugins.vip : false,
+      phpVersion: config.phpVersion || 7.3,
     },
   );
 

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -32,6 +32,10 @@
       "type": "number",
       "errorMessage": "wp.port is not a number"
     },
+    "phpVersion": {
+      "type": "number",
+      "errorMessage": "wp.phpVersion is not a number"
+    },
     "configFile": {
       "type": "string",
       "pattern": "^.*.php$",

--- a/lib/templates/dockerfile.ejs
+++ b/lib/templates/dockerfile.ejs
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:<%= phpVersion %>-apache
 
 RUN apt-get update && apt-get install -y wget libpng-dev libjpeg-dev gnupg default-mysql-client nano less unzip && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd \


### PR DESCRIPTION
## Description
Fixes #68 - Allow user to specify php image version

## Change Log
Edited dockerfile.ejs, createConfig.js and config-valdiation.json to allow a configurable PHP version


## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [ ] Meets provided linting standards.
