### PR TITLE
Fix for Seeder not running outside of CLI.

### DIFF
--- a/plugin/src/Seeder/SeedCommand.php
+++ b/plugin/src/Seeder/SeedCommand.php
@@ -18,7 +18,7 @@ class SeedCommand {
 	 * @param array $args
 	 * @return void
 	 */
-	public function __invoke( array $args, array $assoc_args ): void {
+	public function __invoke( array $args, array $assoc_args = [] ): void {
 		$seeder_name = $args[0];
 
 		if ( empty( $seeder_name ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue where the seeder being called via PHP, rather than via CLI, will not trigger due to additional params not being used. This PR adds in a default value on the second param to ensure that it does not fail in these situations.

## Change Log
* Add default value to second param of Seeder invoke.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
