### PR TITLE
Create a multisite htaccess file when enabled

### DIFF
--- a/config/.htaccess-subdomain
+++ b/config/.htaccess-subdomain
@@ -1,15 +1,21 @@
-# WP-Cypresss Single Site
+# WP-Cypresss Multisite Subdomain
 # This file is a template for the WP-Cypress package. It will be renamed to `.htaccess`.
 # BEGIN WordPress
 # The directives (lines) between `BEGIN WordPress` and `END WordPress` are
 # dynamically generated, and should only be modified via WordPress filters.
 # Any changes to the directives between these markers will be overwritten.
-<IfModule mod_rewrite.c>
 RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /
 RewriteRule ^index\.php$ - [L]
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule . /index.php [L]
-</IfModule>
+
+# add a trailing slash to /wp-admin
+RewriteRule ^wp-admin$ wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^(wp-(content|admin|includes).*) $1 [L]
+RewriteRule ^(.*\.php)$ $1 [L]
+RewriteRule . index.php [L]
 # END WordPress

--- a/config/.htaccess-subfolder
+++ b/config/.htaccess-subfolder
@@ -1,0 +1,20 @@
+# WP-Cypresss Multisite Subfolder
+# This file is a template for the WP-Cypress package. It will be renamed to `.htaccess`.
+# BEGIN WordPress
+# The directives (lines) between `BEGIN WordPress` and `END WordPress` are
+# dynamically generated, and should only be modified via WordPress filters.
+# Any changes to the directives between these markers will be overwritten.
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+# END WordPress

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -131,6 +131,14 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     },
   );
 
+  let htaccessFile = '.htaccess';
+
+  if (config.multisite === 'subdomain') {
+    htaccessFile = `${htaccessFile}-subdomain`;
+  } else if (config.multisite) {
+    htaccessFile = `${htaccessFile}-subfolder`;
+  }
+
   await renderTemplate(
     `${packageDir}/lib/templates/dockerfile.ejs`,
     `${packageDir}/Dockerfile`,
@@ -139,6 +147,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       versions: validVersions,
       vip: config.muPlugins ? config.muPlugins.vip : false,
       phpVersion: config.phpVersion || 7.3,
+      htaccessFile,
     },
   );
 

--- a/lib/templates/dockerfile.ejs
+++ b/lib/templates/dockerfile.ejs
@@ -10,7 +10,7 @@ COPY update.sh /var/www/html
 
 COPY config/php.ini /usr/local/etc/php
 
-COPY config/.htaccess /var/www/html
+COPY config/<%= htaccessFile %> /var/www/html/.htaccess
 
 RUN curl -o /bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
 	&& chmod +x /bin/wp \


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #52 - `.htaccess` files require different configuration depending on whether multisite is enabled and based on which type - subfolder or subdomain. Previously only a single site `.htaccess` file was created no matter the config. To correct this I've introduced two multisite `.htaccess` templates that will be used when their type is selected.

## Change Log
* Added subdomain .htaccess
* Added subfolder htaccess
* Change dockerfile tempalte to use htaccess name variable
* Change config creation to pass htaccess file name to template

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
