### PR TITLE
Add php memory limit to config

### DIFF
--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -1,26 +1,21 @@
-const fs = require("fs-extra");
-const path = require("path");
-const glob = require("glob");
-const { get, defaults } = require("lodash");
-const Ajv = require("ajv");
+const fs = require('fs-extra');
+const path = require('path');
+const glob = require('glob');
+const { get, defaults } = require('lodash');
+const Ajv = require('ajv');
 
-const createDefaultSeeds = require("./createDefaultSeeds");
-const getThemeAndPluginData = require("./getThemeAndPluginData");
-const renderTemplate = require("./renderTemplate");
-const getValidVersions = require("./getValidVersions");
+const createDefaultSeeds = require('./createDefaultSeeds');
+const getThemeAndPluginData = require('./getThemeAndPluginData');
+const renderTemplate = require('./renderTemplate');
+const getValidVersions = require('./getValidVersions');
 
 // Initialize the validation object.
 const validation = new Ajv({ allErrors: true, jsonPointers: true });
-require("ajv-errors")(validation);
+require('ajv-errors')(validation);
 
 // Constants.
-const INVALID_WP_CONTENT_PATH_ERROR = "Path to wp-content is not a directory.";
-const WP_CONTENT_EXCLUDE_PATHS = [
-  "uploads",
-  "upgrade",
-  "node_modules",
-  "cypress",
-];
+const INVALID_WP_CONTENT_PATH_ERROR = 'Path to wp-content is not a directory.';
+const WP_CONTENT_EXCLUDE_PATHS = ['uploads', 'upgrade', 'node_modules', 'cypress'];
 
 /**
  * Generate wp-cypress config, Dockerfile and docker-compose.yml.
@@ -32,35 +27,30 @@ const WP_CONTENT_EXCLUDE_PATHS = [
 const createConfig = async (packageDir, hasVolumeSupport = true) => {
   const CWD = process.cwd();
 
-  const { wp = {}, integrationFolder } = await fs.readJSON(
-    `${CWD}/cypress.json`
-  );
+  const {
+    wp = {},
+    integrationFolder,
+  } = await fs.readJSON(`${CWD}/cypress.json`);
 
   const config = defaults(wp, {
-    seedsPath: "cypress/seeds",
+    seedsPath: 'cypress/seeds',
     wpContent: false,
     multisite: false,
     url: false,
-    phpMemoryLimit: "128M",
+    phpMemoryLimit: '128M',
   });
 
-  const schema = await fs.readJSON(
-    `${packageDir}/lib/schemas/config-validation.json`
-  );
+  const schema = await fs.readJSON(`${packageDir}/lib/schemas/config-validation.json`);
 
   if (!validation.validate(schema, config)) {
-    throw new Error(
-      [
-        validation.errors[0].message,
-        ...[get(validation.errors[0], "params.errors[0].message") || ""],
-      ].join(", ")
-    );
+    throw new Error([
+      validation.errors[0].message,
+      ...[get(validation.errors[0], 'params.errors[0].message') || ''],
+    ].join(', '));
   }
 
   if (!config.url) {
-    config.url = config.port
-      ? `http://localhost:${config.port}`
-      : "http://localhost";
+    config.url = config.port ? `http://localhost:${config.port}` : 'http://localhost';
   }
 
   let volumes = [];
@@ -74,9 +64,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       throw new Error(INVALID_WP_CONTENT_PATH_ERROR);
     }
 
-    const ignore = WP_CONTENT_EXCLUDE_PATHS.map(
-      (exclude) => `${pathToWPContent}/${exclude}`
-    );
+    const ignore = WP_CONTENT_EXCLUDE_PATHS.map((exclude) => `${pathToWPContent}/${exclude}`);
 
     if (config.muPlugins) {
       ignore.push(`${pathToWPContent}/mu-plugins`);
@@ -95,10 +83,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       activeTheme = config.wpContent.activeTheme;
     }
   } else {
-    const { plugins, themes } = getThemeAndPluginData(
-      config.plugins,
-      config.themes
-    );
+    const { plugins, themes } = getThemeAndPluginData(config.plugins, config.themes);
 
     if (plugins.length > 0) {
       activePlugins = plugins.map((x) => x.name);
@@ -110,8 +95,8 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
 
     volumes = [
       ...volumes,
-      ...plugins.map((x) => x.volume),
-      ...themes.map((x) => x.volume),
+      ...(plugins.map((x) => x.volume)),
+      ...(themes.map((x) => x.volume)),
     ];
   }
 
@@ -121,28 +106,20 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
 
   volumes.push(
     `${seedsDir}:/var/www/html/seeds`,
-    `${packageDir}/plugin:/var/www/html/wp-content/plugins/wp-cypress`
+    `${packageDir}/plugin:/var/www/html/wp-content/plugins/wp-cypress`,
   );
 
   if (config.configFile) {
-    volumes.push(
-      `${path.resolve(config.configFile)}:/var/www/html/wp-cypress-config.php`
-    );
+    volumes.push(`${path.resolve(config.configFile)}:/var/www/html/wp-cypress-config.php`);
   }
 
   if (config.muPlugins && config.muPlugins.path) {
     const muPluginsLocation = path.resolve(config.muPlugins.path);
-    const muPluginsDestination = config.muPlugins.vip
-      ? "client-mu-plugins"
-      : "mu-plugins";
-    volumes.push(
-      `${muPluginsLocation}:/var/www/html/wp-content/${muPluginsDestination}`
-    );
+    const muPluginsDestination = config.muPlugins.vip ? 'client-mu-plugins' : 'mu-plugins';
+    volumes.push(`${muPluginsLocation}:/var/www/html/wp-content/${muPluginsDestination}`);
   }
 
-  const version = Array.isArray(config.version)
-    ? config.version
-    : [config.version];
+  const version = Array.isArray(config.version) ? config.version : [config.version];
   const validVersions = await getValidVersions(version);
 
   await renderTemplate(
@@ -152,12 +129,12 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       port: config.port || 80,
       dbPort: config.dbPort || 3306,
       volumes: hasVolumeSupport ? volumes : false,
-    }
+    },
   );
 
-  let htaccessFile = ".htaccess";
+  let htaccessFile = '.htaccess';
 
-  if (config.multisite === "subdomain") {
+  if (config.multisite === 'subdomain') {
     htaccessFile = `${htaccessFile}-subdomain`;
   } else if (config.multisite) {
     htaccessFile = `${htaccessFile}-subfolder`;
@@ -171,9 +148,9 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       versions: validVersions,
       vip: config.muPlugins ? config.muPlugins.vip : false,
       phpVersion: config.phpVersion || 7.3,
-      phpMemoryLimit: config.phpMemoryLimit || "128M",
+      phpMemoryLimit: config.phpMemoryLimit || '128M',
       htaccessFile,
-    }
+    },
   );
 
   const wpCypressConfig = {

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -37,6 +37,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     wpContent: false,
     multisite: false,
     url: false,
+    phpMemoryLimit: '128M',
   });
 
   const schema = await fs.readJSON(`${packageDir}/lib/schemas/config-validation.json`);
@@ -131,6 +132,8 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     },
   );
 
+  console.log(config);
+
   await renderTemplate(
     `${packageDir}/lib/templates/dockerfile.ejs`,
     `${packageDir}/Dockerfile`,
@@ -139,6 +142,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       versions: validVersions,
       vip: config.muPlugins ? config.muPlugins.vip : false,
       phpVersion: config.phpVersion || 7.3,
+      phpMemoryLimit: config.phpMemoryLimit || '128M',
     },
   );
 

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -36,6 +36,11 @@
       "type": "number",
       "errorMessage": "wp.phpVersion is not a number"
     },
+    "phpMemoryLimit": {
+      "type": "string",
+      "pattern": "^[0-9]{2,}(M|G)$",
+      "errorMessage": "wp.phpMemorylimit is not valid"
+    },
     "dbPort": {
       "type": "number",
       "errorMessage": "wp.dbPort is not a number"

--- a/lib/templates/dockerfile.ejs
+++ b/lib/templates/dockerfile.ejs
@@ -8,6 +8,8 @@ RUN a2enmod rewrite
 
 COPY update.sh /var/www/html
 
+ENV PHP_MEMORY_LIMIT=<%= phpMemoryLimit %>
+
 COPY config/php.ini /usr/local/etc/php
 
 COPY config/.htaccess /var/www/html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #54 - adds configuration option `wp.phpMemoryLimit` to set the `PHP_MEMORY_LIMIT` environment variable.

## Change Log
* Add `phpMemoryLimit` config validation.
* Add `PHP_MEMORY_LIMIT` to Dockerfile and related templates.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
