### PR TITLE
Bump default PHP version to 7.4

### DIFF
--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -138,7 +138,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       isWpContent: config.wpContent,
       versions: validVersions,
       vip: config.muPlugins ? config.muPlugins.vip : false,
-      phpVersion: config.phpVersion || 7.3,
+      phpVersion: config.phpVersion || 7.4,
     },
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As PHP 7.3 reached End of Life 10 days ago (6th Dec 2021) we should ensure that we are at least using the minimum supported version as the install default.

https://www.php.net/supported-versions.php

## Change Log
* Changed default PHP version to target `7.4`.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
