### PR TITLE
Cucumber multi-wp installs

### DIFF
--- a/lib/cypress-plugin/modifySpec.js
+++ b/lib/cypress-plugin/modifySpec.js
@@ -22,6 +22,13 @@ const path = require('path');
  * @returns {String} - New spec file with added before block
  */
 module.exports = (fileContents, version, source, target) => {
+  const re = /(?:\.([^.]+))?$/;
+
+  // Only parse the following files.
+  if (!['js', 'jsx', 'ts', 'tsx'].includes(re.exec(source)[0])) {
+    return fileContents;
+  }
+
   const beforeBlock = esprima.parseScript(`
     before(() => {
       const path = require('path');
@@ -35,6 +42,8 @@ module.exports = (fileContents, version, source, target) => {
       cy.resetWP();
     });
   `).body[0];
+
+  console.log(fileContents);
 
   const parsed = esprima.parseModule(fileContents);
 

--- a/lib/cypress-plugin/modifySpec.js
+++ b/lib/cypress-plugin/modifySpec.js
@@ -43,8 +43,6 @@ module.exports = (fileContents, version, source, target) => {
     });
   `).body[0];
 
-  console.log(fileContents);
-
   const parsed = esprima.parseModule(fileContents);
 
   const parsedFileWithInsert = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There have been difficulties getting Cucumber and `.feature` files running on multi-wp testing setups. This seems to be happening because during the copy and parse of the test files, WP-Cypress is attempting to parse `.feature` files as though they are `.js` files. This parsing is not required for these files, so they can and should be skipped.

## Change Log
* Adds file check to parse script.

## Screenshots/Videos
_If PR includes visual changes, please include a screenshot (or short video if applicable)._
<img width="932" alt="Screenshot 2022-07-17 at 23 14 09" src="https://user-images.githubusercontent.com/3148834/179426796-5daa6e6a-c3b6-4637-940d-c7a1bed3f4d0.png">

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
