### PR TITLE
Added a property in wpContents which activates plugins after the theme is activated.

### DIFF
--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -118,6 +118,22 @@ if( file_exists ( ABSPATH . '.userid' ) ) {
     );
   }
 
+  if (config.pluginsActivatedAfterTheme.length > 0) {
+    await run(
+      async () =>
+        wpcli(
+          `plugin activate wp-cypress ${config.pluginsActivatedAfterTheme.join(' ')} ${
+            config.multisite ? '--network' : ''
+          }`,
+          logFile,
+        ),
+      'Activating theme-dependent plugins',
+      'Activated theme-dependent plugins',
+      logFile,
+      false,
+    );
+  }
+
   await run(
     async () => wpcli('seed DefaultUsers', logFile),
     'Creating default users',

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -55,6 +55,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
   let volumes = [];
   let activePlugins = [];
   let activeTheme = false;
+  let pluginsActivatedAfterTheme = [];
 
   if (config.wpContent) {
     const pathToWPContent = path.resolve(config.wpContent.path);
@@ -80,6 +81,10 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
 
     if (config.wpContent.activeTheme) {
       activeTheme = config.wpContent.activeTheme;
+    }
+
+    if (config.wpContent.pluginsActivatedAfterTheme) {
+      pluginsActivatedAfterTheme = config.wpContent.pluginsActivatedAfterTheme;
     }
   } else {
     const { plugins, themes } = getThemeAndPluginData(config.plugins, config.themes);
@@ -151,6 +156,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     volumes,
     activePlugins,
     activeTheme,
+    pluginsActivatedAfterTheme,
     // We need to store the user integration folder because we replaces cypress's
     // configuration path to the integration folder with a path to the
     // temp integration folder but we still need to be aware of the original.

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -117,6 +117,13 @@
                 "type": "string"
               },
               "errorMessage": "wp.wpContent.activePlugins is not an array of strings"
+            },
+            "pluginsActivatedAfterTheme": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "errorMessage": "wp.wpContent.pluginsActivatedAfterTheme is not an array of strings"
             }
           },
           "required": [


### PR DESCRIPTION
## Description
Fixes https://github.com/bigbite/wp-cypress/issues/95 -  Adds support for a new property called `pluginsActivatedAfterTheme` in the `wpContents` object in `cypress.json`.  Plugins applied to this property get activated after the theme is activated allowing WP-Cypress to test plugins that depend on the them.

## Change Log
* Adds support for `wpContents.pluginsActivatedAfterTheme` in `cypress.json`.  
* `wpContents.pluginsActivatedAfterTheme` is an array of plugins which will get activated after the theme is.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.

# To be added to the Schema upon release:
Add this to the wpContents section

| Property      | Required  
| ------------- | -------- 
| [pluginsActivatedAfterTheme](#pluginsActivatedAfterTheme) | Optional 

## pluginsActivatedAfterTheme
-   Type: `string[]`