### PR TITLE
Write command output to `stdout` - Typos/grammar mistakes - JSDoc comments improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cypress is designed to address the pain points of testing modern web application
 
 ## Documentation
 
-Please refer to the [Github Wiki](https://github.com/bigbite/wp-cypress/wiki) for documentation.
+Please refer to the [GitHub Wiki](https://github.com/bigbite/wp-cypress/wiki) for documentation.
 
 ## Contributing
 
@@ -27,11 +27,3 @@ Please refer to our [contributing guidelines](https://github.com/bigbite/wp-cypr
 
 ## Changelog
 Please refer to the [Releases page](https://github.com/bigbite/wp-cypress/releases) for the changelog.
-
-
-
-
-
-
-
-

--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -8,11 +8,13 @@ const copyVolumes = require('../../modules/copyVolumes');
 const getWPInstallType = require('../../modules/getWPInstallType');
 
 /**
- * Restore WP to it's initial state.
+ * Restore WP to its initial state.
  *
- * @param {String} packageDir - Path to the package directory.
- * @param {Object} logFile - Logfile to output stdout and stderr.
- * @param {Object} options - CLI options.
+ * @param {string} packageDir - Path to the package directory.
+ * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {object} options - CLI options.
+ *
+ * @return {Promise<void>}
  */
 const reset = async (packageDir, logFile, options) => {
   const config = fs.readJsonSync(`${packageDir}/config.json`);

--- a/lib/cli/commands/softReset.js
+++ b/lib/cli/commands/softReset.js
@@ -8,9 +8,11 @@ const run = require('../../modules/run');
 /**
  * Soft reset by importing database.
  *
- * @param {String} packageDir - Path to the package directory.
- * @param {Object} logFile - Logfile to output stdout and stderr.
- * @param {Object} options - CLI options.
+ * @param {string} packageDir - Path to the package directory.
+ * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {object} options - CLI options.
+ *
+ * @return {Promise<void>}
  */
 const softReset = async (packageDir, logFile, options = false) => {
   const config = fs.readJsonSync(`${packageDir}/config.json`);

--- a/lib/cli/commands/start.js
+++ b/lib/cli/commands/start.js
@@ -8,8 +8,12 @@ const reset = require('./reset');
 
 /**
  * Start the docker the test container and wait for the database to be connected.
- * @param {String} packageDir - Path to the package directory.
- * @param {Object} logFile - Logfile to output stdout and stderr.
+ *
+ * @param {string} packageDir - Path to the package directory.
+ * @param {object} options - CLI options.
+ * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ *
+ * @return {Promise<void>}
  */
 const start = async (packageDir, options, logFile) => {
   const config = await createConfig(packageDir, options.volumes);

--- a/lib/cli/commands/stop.js
+++ b/lib/cli/commands/stop.js
@@ -5,8 +5,11 @@ const { exec } = require('../../modules/exec');
 
 /**
  * Stop and remove the test container.
- * @param {String} packageDir - Path to the package directory.
- * @param {Object} logFile - Logfile to output stdout and stderr.
+ *
+ * @param {string} packageDir - Path to the package directory.
+ * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ *
+ * @return {Promise<void>} - A Promise that resolves when the test environment has been stopped.
  */
 const stop = async (packageDir, logFile) => {
   shell.cd(packageDir);

--- a/lib/cli/commands/wp.js
+++ b/lib/cli/commands/wp.js
@@ -9,13 +9,21 @@ const run = require('../../modules/run');
  * @param {string} command - The command to execute.
  * @param {string} packageDir - Path to the package directory.
  * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {boolean} [writeToStdout=false] - Optionally, whether to write the output to `stdout`.
  *
  * @return {Promise<void>} - A Promise that resolves when the command has finished executing.
  */
-const wp = async (command, packageDir, logFile) => {
+const wp = async (command, packageDir, logFile, writeToStdout = false) => {
   shell.cd(packageDir);
 
-  await run(async () => wpcli(command, logFile), `Running wp ${command}`);
+  await run(
+    async () => wpcli(command, logFile),
+    `Running wp ${command}`,
+    false,
+    false,
+    true,
+    writeToStdout,
+  );
 };
 
 module.exports = wp;

--- a/lib/cli/commands/wp.js
+++ b/lib/cli/commands/wp.js
@@ -4,10 +4,13 @@ const { wpcli } = require('../../modules/exec');
 const run = require('../../modules/run');
 
 /**
- * Execute the wordpress cli inside the test container.
- * @param {Sting} command - The command to execute.
- * @param {String} packageDir - Path to the package directory.
- * @param {Object} logFile - Logfile to output stdout and stderr.
+ * Execute the WordPress CLI inside the test container.
+ *
+ * @param {string} command - The command to execute.
+ * @param {string} packageDir - Path to the package directory.
+ * @param {object} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ *
+ * @return {Promise<void>} - A Promise that resolves when the command has finished executing.
  */
 const wp = async (command, packageDir, logFile) => {
   shell.cd(packageDir);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -42,9 +42,14 @@ program
   .action((options) => softReset(packageDir, logFile, options));
 
 program
-  .command('wp <command>')
+  .command('wp')
   .description('Execute the WordPress CLI in the running container')
-  .action((command) => wp(command, packageDir, logFile));
+  .option('<command>', 'The WP-CLI command to execute')
+  .option('-w,--write-to-stdout', 'Whether to write the output to stdout')
+  .action((options) => {
+    const command = options.args.join(' ');
+    wp(command, packageDir, logFile, !!options.writeToStdout);
+  });
 
 program
   .command('seed')

--- a/lib/cypress-plugin/modifySpec.js
+++ b/lib/cypress-plugin/modifySpec.js
@@ -15,11 +15,12 @@ const path = require('path');
  *
  * @see https://github.com/cypress-io/cypress/issues/3090
  *
- * @param {String} fileContents - Contents of spec file
- * @param {String} version - Wp version spec to be ran in
- * @param {String} source - Origional source of spec file
- * @param {String} target - New target source for spec file.
- * @returns {String} - New spec file with added before block
+ * @param {string} fileContents - Contents of spec file.
+ * @param {string} version - WP version spec to be run in.
+ * @param {string} source - Original source of spec file.
+ * @param {string} target - New target source for spec file.
+ *
+ * @return {string} - New spec file with added before block.
  */
 module.exports = (fileContents, version, source, target) => {
   const beforeBlock = esprima.parseScript(`

--- a/lib/cypress-support/commands.js
+++ b/lib/cypress-support/commands.js
@@ -6,23 +6,23 @@ const wpCypress =
 
 const commands = {
   wp(command) {
-    cy.exec(`${wpCypress} wp "${command}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "${command}"`);
   },
 
   seed(seeder) {
-    cy.exec(`${wpCypress} wp "seed ${seeder}"`).then((result) => {
+    cy.exec(`${wpCypress} wp --write-to-stdout "seed ${seeder}"`).then((result) => {
       cy.log(result.stdout);
     });
   },
 
   seedClean(seeder) {
-    cy.exec(`${wpCypress} wp "seed ${seeder} --clean"`).then((result) => {
+    cy.exec(`${wpCypress} wp --write-to-stdout "seed ${seeder} --clean"`).then((result) => {
       cy.log(result.stdout);
     });
   },
 
   cleanThenSeed(seeder) {
-    cy.exec(`${wpCypress} wp "seed ${seeder} --clean-first"`).then((result) => {
+    cy.exec(`${wpCypress} wp --write-to-stdout "seed ${seeder} --clean-first"`).then((result) => {
       cy.log(result.stdout);
     });
   },
@@ -34,23 +34,23 @@ const commands = {
   },
 
   installTheme(name) {
-    cy.exec(`${wpCypress} wp "theme install ${name}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "theme install ${name}"`);
   },
 
   activateTheme(name) {
-    cy.exec(`${wpCypress} wp "theme activate ${name}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "theme activate ${name}"`);
   },
 
   installPlugin(name) {
-    cy.exec(`${wpCypress} wp "plugin install ${name}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "plugin install ${name}"`);
   },
 
   activatePlugin(name) {
-    cy.exec(`${wpCypress} wp "plugin activate ${name}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "plugin activate ${name}"`);
   },
 
   deactivatePlugin(name) {
-    cy.exec(`${wpCypress} wp "plugin deactivate ${name}"`);
+    cy.exec(`${wpCypress} wp --write-to-stdout "plugin deactivate ${name}"`);
   },
 
   visitAdmin(options = {}) {
@@ -67,7 +67,7 @@ const commands = {
 
   switchUser(user = 'admin', password = null) {
     if (password) {
-      cy.exec(`${wpCypress} wp "wp-cypress-set-user --logout"`).then(() => {
+      cy.exec(`${wpCypress} wp --write-to-stdout "wp-cypress-set-user --logout"`).then(() => {
         cy.clearCookies();
         cy.visit('/wp-login.php?loggedout=true');
 
@@ -83,12 +83,12 @@ const commands = {
         cy.get('#wp-submit').click();
       });
     } else {
-      cy.exec(`${wpCypress} wp "wp-cypress-set-user ${user}"`);
+      cy.exec(`${wpCypress} wp --write-to-stdout "wp-cypress-set-user ${user}"`);
     }
   },
 
   logout() {
-    cy.exec(`${wpCypress} wp "wp-cypress-set-user --logout"`).then(() => {
+    cy.exec(`${wpCypress} wp --write-to-stdout "wp-cypress-set-user --logout"`).then(() => {
       cy.clearCookies();
       cy.visit('/wp-login.php?loggedout=true');
     });

--- a/lib/modules/copyVolumes.js
+++ b/lib/modules/copyVolumes.js
@@ -4,9 +4,12 @@ const run = require('./run');
 
 /**
  * Copy a file|folder on the host to the container.
+ *
  * @param {string} location
- * @param {location} destination
- * @param {*} logFile
+ * @param {string} destination
+ * @param {string} logFile
+ *
+ * @return {Promise<void>}
  */
 const copyToContainer = async (location, destination, logFile) => {
   if (destination) {
@@ -27,9 +30,12 @@ const copyToContainer = async (location, destination, logFile) => {
 
 /**
  * Copy volumes instead of mounting.
+ *
  * @param {Array} volumes
- * @param {Boolean} isWpContent
- * @param {Object} logFile
+ * @param {boolean} isWpContent
+ * @param {object} logFile
+ *
+ * @return {Promise<void>}
  */
 const copyVolumes = async (volumes, isWpContent, logFile) => {
   // eslint-disable-next-line no-restricted-syntax

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -24,6 +24,7 @@ const WP_CONTENT_EXCLUDE_PATHS = ['uploads', 'upgrade', 'node_modules', 'cypress
  *
  * @param {string} packageDir
  * @param {boolean} hasVolumeSupport
+ *
  * @return {object}
  */
 const createConfig = async (packageDir, hasVolumeSupport = true) => {

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -165,9 +165,9 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     volumes,
     activePlugins,
     activeTheme,
-    // We need to store the user integration folder because we replaces cypress's
+    // We need to store the user integration folder because we replace cypress's
     // configuration path to the integration folder with a path to the
-    // temp integration folder but we still need to be aware of the original.
+    // temp integration folder, but we still need to be aware of the original.
     userIntegrationFolder: integrationFolder || `${CWD}/cypress/integration`,
   };
 

--- a/lib/modules/createDefaultSeeds.js
+++ b/lib/modules/createDefaultSeeds.js
@@ -1,10 +1,12 @@
 const fs = require('fs-extra');
 
 /**
- * If there is no seeds directory, create one with default and examples.
+ * If there is no `seeds` directory, create one with default and examples.
  *
  * @param {string} seedsDir
  * @param {string} packageDir
+ *
+ * @return {void}
  */
 const createDefaultSeeds = (seedsDir, packageDir) => {
   if (fs.existsSync(seedsDir)) {

--- a/lib/modules/exec.js
+++ b/lib/modules/exec.js
@@ -4,8 +4,8 @@ const shell = require('shelljs');
  * Execute a command.
  *
  * @param {string} cmd - The command to execute.
- * @param {object|false} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
- * @param {string|false} stdin - Input to pass to the command.
+ * @param {object} [logFile] - Optionally, an instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {string} [stdin] - Optionally, input to pass to the command.
  *
  * @return {Promise<{code: number, stdout: string, stderr: string}>} - A Promise that resolves to an object containing
  *                                                                     the process exit code, stdout, and stderr.

--- a/lib/modules/exec.js
+++ b/lib/modules/exec.js
@@ -1,5 +1,15 @@
 const shell = require('shelljs');
 
+/**
+ * Execute a command.
+ *
+ * @param {string} cmd - The command to execute.
+ * @param {object|false} logFile - Instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {string|false} stdin - Input to pass to the command.
+ *
+ * @return {Promise<{code: number, stdout: string, stderr: string}>} - A Promise that resolves to an object containing
+ *                                                                     the process exit code, stdout, and stderr.
+ */
 const exec = (cmd, logFile, stdin) =>
   new Promise((resolve) => {
     let child;

--- a/lib/modules/getThemeAndPluginData.js
+++ b/lib/modules/getThemeAndPluginData.js
@@ -4,9 +4,13 @@ const glob = require('glob');
 /**
  * Retrieve the required plug or theme data from config.
  *
- * @param {array} globs
- * @param {string} type
- * @returns {array}
+ * @param {string[]} pluginGlobs
+ * @param {string[]} themeGlobs
+ *
+ * @return {{
+ *   plugins: Array.<{name: string, path: string, volume: string}>,
+ *   themes: Array.<{name: string, path: string, volume: string}>
+ * }}
  */
 const getThemeAndPluginData = (pluginGlobs = [], themeGlobs = []) => {
   const plugins = [];

--- a/lib/modules/run.js
+++ b/lib/modules/run.js
@@ -1,6 +1,21 @@
 const ora = require('ora');
 const shell = require('shelljs');
 
+/**
+ * Run a command.
+ *
+ * @param {function: Promise<{code: number, stdout: string, stderr: string}>} command - A function to execute a command
+ *                                                                                      and return a Promise that
+ *                                                                                      resolves to an object
+ *                                                                                      containing the process exit
+ *                                                                                      code, stdout, and stderr.
+ * @param {string} start - The message to display when the command starts running.
+ * @param {string|false} succeed - Optionally, a message to display when the command succeeds.
+ * @param {object|false} logFile - Optionally, an instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {boolean} exitOnError - Optionally, whether to exit the process when the command fails.
+ *
+ * @return {Promise<void>} - A Promise that resolves when the command has finished running.
+ */
 const run = async (command, start, succeed = false, logFile = false, exitOnError = true) => {
   const spinner = ora({
     text: start,

--- a/lib/modules/run.js
+++ b/lib/modules/run.js
@@ -10,9 +10,9 @@ const shell = require('shelljs');
  *                                                                                      containing the process exit
  *                                                                                      code, stdout, and stderr.
  * @param {string} start - The message to display when the command starts running.
- * @param {string|false} succeed - Optionally, a message to display when the command succeeds.
- * @param {object|false} logFile - Optionally, an instance of `fs.WriteStream` to output `stdout` and `stderr`.
- * @param {boolean} exitOnError - Optionally, whether to exit the process when the command fails.
+ * @param {string|false} [succeed=false] - Optionally, a message to display when the command succeeds.
+ * @param {object|false} [logFile=false] - Optionally, an instance of `fs.WriteStream` to output `stdout` and `stderr`.
+ * @param {boolean} [exitOnError=true] - Optionally, whether to exit the process when the command fails.
  *
  * @return {Promise<void>} - A Promise that resolves when the command has finished running.
  */

--- a/lib/modules/run.js
+++ b/lib/modules/run.js
@@ -13,10 +13,18 @@ const shell = require('shelljs');
  * @param {string|false} [succeed=false] - Optionally, a message to display when the command succeeds.
  * @param {object|false} [logFile=false] - Optionally, an instance of `fs.WriteStream` to output `stdout` and `stderr`.
  * @param {boolean} [exitOnError=true] - Optionally, whether to exit the process when the command fails.
+ * @param {boolean} [writeToStdout=false] - Optionally, whether to write the output to `stdout`.
  *
  * @return {Promise<void>} - A Promise that resolves when the command has finished running.
  */
-const run = async (command, start, succeed = false, logFile = false, exitOnError = true) => {
+const run = async (
+  command,
+  start,
+  succeed = false,
+  logFile = false,
+  exitOnError = true,
+  writeToStdout = false,
+) => {
   const spinner = ora({
     text: start,
     prefixText: 'wp-cypress',
@@ -51,6 +59,10 @@ const run = async (command, start, succeed = false, logFile = false, exitOnError
   }
 
   spinner.succeed(succeed || stdout);
+
+  if (writeToStdout) {
+    process.stdout.write(succeed || stdout);
+  }
 };
 
 module.exports = run;

--- a/lib/utils/async-map.js
+++ b/lib/utils/async-map.js
@@ -1,10 +1,10 @@
 /**
- * Async version of array map
+ * Async version of array map.
  *
- * @param {array} array - Items to iterate
- * @param {promise} promise - Promise to exec
+ * @param {Array} array - Items to iterate.
+ * @param {Promise} promise - Promise to exec.
  *
- * @returns {promise<array>}
+ * @return {Promise<Array>}
  */
 const asyncMap = async (array, promise) => {
   const promises = array.map(async (x) => {

--- a/lib/utils/copy.js
+++ b/lib/utils/copy.js
@@ -4,11 +4,13 @@ const junk = require('junk');
 const isUnixHiddenPath = require('./is-unix-hidden-path');
 
 /**
- * Copy a file and modify it's contents.
+ * Copy a file and modify its contents.
  *
  * @param {string} src
  * @param {string} dest
  * @param {function} modifier
+ *
+ * @return {void}
  */
 const copyFileSync = (src, dest, modifier) => {
   let fileContents = fs.readFileSync(src, { encoding: 'utf8' });
@@ -26,7 +28,9 @@ const copyFileSync = (src, dest, modifier) => {
  * @param {string} src
  * @param {string} dest
  * @param {function} modifier
- * @param {array} filters
+ * @param {Array} filters
+ *
+ * @return {void}
  */
 const copyDirSync = (src, dest, modifier = false, filters = []) => {
   if (filters.some((x) => src.includes(x))) {

--- a/lib/utils/is-unix-hidden-path.js
+++ b/lib/utils/is-unix-hidden-path.js
@@ -1,9 +1,9 @@
 /**
- * Checks whether a path starts with or contains a hidden file or a folder
+ * Check whether a path starts with or contains a hidden file or a folder.
  *
- * @param {string} path - The path of the file that needs to be validated
+ * @param {string} path - The path of the file that needs to be validated.
  *
- * @returns {boolean}
+ * @return {boolean}
  */
 const isUnixHiddenPath = (path) => /(^|\/)\.[^/.]/g.test(path);
 

--- a/lib/utils/sleep.js
+++ b/lib/utils/sleep.js
@@ -2,6 +2,8 @@
  * Sleep for a period of milliseconds.
  *
  * @param {number} ms
+ *
+ * @return {Promise<void>}
  */
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
## Description

Fixes #113.

The first 4 commits are minor (typos, grammar mistakes, and JSDoc comments). The actual change (related to #113) is in 96ef4ff and affects the following files:

- `lib/cli/index.js`
- `lib/cli/commands/wp.js`
- `lib/cypress-support/commands.js`
- `lib/modules/run.js`

It basically introduces the `-w` (or `--write-to-stdout`) flag for the `wp` command:

```javascript
program
  .command('wp')
  .description('Execute the WordPress CLI in the running container')
  .option('<command>', 'The WP-CLI command to execute')
  .option('-w,--write-to-stdout', 'Whether to write the output to stdout')
  .action((options) => {
    const command = options.args.join(' ');
    wp(command, packageDir, logFile, !!options.writeToStdout);
  });
```

and adds an additional (`boolean`) parameter for that flag to:

- `wp()` (in `lib/cli/commands/wp.js`), which simply passes the value to `run()`

- `run()` (in `/lib/modules/run.js`), which uses that value to determine whether we should write to `stdout` or not (that way, we prevent CLI users from getting duplicate output)

    ```javascript
    if (writeToStdout) {
      process.stdout.write(succeed || stdout);
    }
    ```

The new `writeToStdout` parameter is going to be `false`, by default. We're only setting the flag for the WP Cypress commands in `lib/cli/cypress-support/commands.js`.

So, we're essentially changing this:

```javascript
wp(command) {
  cy.exec(`${wpCypress} wp "${command}"`);
}
```

to that:

```javascript
wp(command) {
  cy.exec(`${wpCypress} wp --write-to-stdout "${command}"`);
}
```

I've tested the changes described in this PR on a couple of projects (and with my own Cypress commands) and AFAICT everything is working as expected.

Let me know if you need any more information! 🙂

## Change Log

* Writes command output to `stdout` while keeping `stderr` as it is, to prevent any breaking changes (as described in #113). It introduces an internally used `-w, --write-to-stdout` flag for the `wp` command, to prevent CLI users from getting a duplicate output.
* In addition to the `stdout` change, this PR fixes a few minor typos and grammar mistakes
* and improves JSDoc comments a bit (consistent tags, capitalization, updates mismatching param names, documents object structures, and adds missing `@return` tags)

## Screenshots/Videos

N/A

## Types of changes (_if applicable_):

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):

- [x] Meets provided linting standards.
