### PR TITLE
Fixes an issue where WP-Cypress could not find cypress/package.json

### DIFF
--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -30,7 +30,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
   const CWD = process.cwd();
 
   // eslint-disable-next-line import/no-unresolved
-  const { version: cypressVersion } = require('../../../../cypress/package.json');
+  const { version: cypressVersion } = require(`${CWD}/node_modules/cypress/package.json`);
 
   let configFile;
 


### PR DESCRIPTION
## Description
In `createConfig.js`, WP-Cypress could not find the `cypress/package.json` since the path was a relative one.  This PR fixes it by turning it into an absolute path which means that the cypress version can be properly extracted.

## Change Log
* Fixed an issue where WP-Cypress could not find `cypress/package.json` which means that it wasn't getting the cypress version.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
