### PR TITLE
NPB-742: Enabled encoded URL to fix chart embed code

### DIFF
--- a/config/000-default.conf
+++ b/config/000-default.conf
@@ -1,0 +1,32 @@
+<VirtualHost *:80>
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        #ServerName www.example.com
+
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/html
+
+        # Enable AllowEncodedSlashes to support special characters in URL
+        AllowEncodedSlashes On
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include conf-available/serve-cgi-bin.conf
+</VirtualHost>

--- a/lib/templates/dockerfile.ejs
+++ b/lib/templates/dockerfile.ejs
@@ -12,6 +12,8 @@ ENV PHP_MEMORY_LIMIT=<%= phpMemoryLimit %>
 
 COPY config/php.ini /usr/local/etc/php
 
+COPY config/000-default.conf /etc/apache2/sites-available
+
 COPY config/<%= htaccessFile %> /var/www/html/.htaccess
 
 RUN curl -o /bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \


### PR DESCRIPTION
## Description
Fixes #NPB-742 - Unable to test dynamic inset block on local environment through automation.

## Change Log
* Fixed an issue where QA team not was not able to test Dynamic Insets plugin in automation as Apache config was not allowing to encoded URL 

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/68051977/220377205-9a2ac815-da4c-498b-a369-a878276cc43d.png)

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
