### PR TITLE
feat: allow admin username to set from config adminUsername

### DIFF
--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -86,7 +86,7 @@ if( file_exists ( ABSPATH . '.userid' ) ) {
       wpcli(
         `core ${getWPInstallType(config.multisite)} --url=${
           config.url
-        } --title="WP Cypress" --admin_user=admin --admin_password=password --admin_email="admin@test.com" --skip-email`,
+        } --title="WP Cypress" --admin_user=${config.adminUsername} --admin_password=password --admin_email="admin@test.com" --skip-email`,
         logFile,
       ),
     'Installing WordPress',
@@ -118,9 +118,9 @@ if( file_exists ( ABSPATH . '.userid' ) ) {
   );
 
   await run(
-    async () => wpcli('wp-cypress-set-user admin', logFile),
-    'Set user to admin',
-    'User set to admin',
+    async () => wpcli(`wp-cypress-set-user ${config.adminUsername}`, logFile),
+    `Set user to  ${config.adminUsername}`,
+    `User set to  ${config.adminUsername}`,
     logFile,
   );
 

--- a/lib/cli/commands/softReset.js
+++ b/lib/cli/commands/softReset.js
@@ -22,9 +22,9 @@ const softReset = async (packageDir, logFile, options = false) => {
   await cli(`bash update.sh ${version} false`, logFile);
 
   await run(
-    async () => wpcli('wp-cypress-set-user admin', logFile),
-    'Set user to admin',
-    'User set to admin',
+    async () => wpcli(`wp-cypress-set-user ${config.adminUsername}`, logFile),
+    `Set user to  ${config.adminUsername}`,
+    `User set to  ${config.adminUsername}`,
     logFile,
   );
 

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -48,6 +48,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
     multisite: false,
     url: false,
     phpMemoryLimit: '128M',
+    adminUsername: 'admin',
   });
 
   const schema = await fs.readJSON(`${packageDir}/lib/schemas/config-validation.json`);

--- a/lib/schemas/config-validation.json
+++ b/lib/schemas/config-validation.json
@@ -20,6 +20,10 @@
       "type": "string",
       "errorMessage": "wp.seedsPath is not a string"
     },
+    "adminUsername": {
+      "type": "string",
+      "errorMessage": "wp.adminUsername is not a string"
+    },
     "multisite": {
       "type": ["boolean", "string"],
       "errorMessage": "multisite is not set to false, true or subdomains"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Give developers the ability to configure the username used so that the setup can meet VIP rules/setup.

## Change Log
* Ability to set WordPress admin username in config via `adminUsername` property.
  * Will default to `admin`. 

## Screenshots/Videos
_If PR includes visual changes, please include a screenshot (or short video if applicable)._

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
