### PR TITLE
Avoid toggling welcome message when core/nux is not available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "WordPress end to end testing with Cypress.io",
   "repository": "https://github.com/bigbite/wp-cypress",
   "author": {

--- a/plugin/assets/disable-tooltips.js
+++ b/plugin/assets/disable-tooltips.js
@@ -6,10 +6,6 @@ jQuery(document).ready(() => {
   const nux = select('core/nux');
 
   if (!nux) {
-    if (select('core/edit-post').isFeatureActive('welcomeGuide')) {
-      dispatch('core/edit-post').toggleFeature('welcomeGuide');
-    }
-
     return;
   }
 


### PR DESCRIPTION
## Description

Since the deprecation of the `core/nux` store, the default WordPress 'welcome guide' modal can only be toggled on or off, not explicitly disabled.

In order to prevent the welcome guide from showing, which can block test execution, we are checking whether it is enabled, then toggling it to disable it.

This appears to cause a situation where the welcome guide is dismissed automatically when Cypress interacts with the page, after which our code (which is intended to dismiss the welcome guide) actually toggles it back on and blocks further test execution.

This is only visible since WordPress 6.2 as this is when the `core/nux` package was removed, after being deprecated for some time.

By removing the call to toggle the welcome guide, this issue is avoided and it appears that the welcome guide is automatically dismissed without interfering with the test execution.

## Change Log
* Remove the call to toggle the welcome modal if `core/nux` is not found

## Screenshots/Videos

This has been tested on 6.2 and 6.0 to check backwards compatibility.

> Note: I want to test this further especially since the issue doesn't seem to crop up on CI

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
