### PR TITLE
Adds user meta to admin to prevent the Welcome Message modal appearing in the Gutenberg editor

### DIFF
--- a/lib/cli/commands/reset.js
+++ b/lib/cli/commands/reset.js
@@ -88,7 +88,9 @@ if( file_exists ( ABSPATH . '.userid' ) ) {
       wpcli(
         `core ${getWPInstallType(config.multisite)} --url=${
           config.url
-        } --title="WP Cypress" --admin_user=${config.adminUsername} --admin_password=password --admin_email="admin@test.com" --skip-email`,
+        } --title="WP Cypress" --admin_user=${
+          config.adminUsername
+        } --admin_password=password --admin_email="admin@test.com" --skip-email`,
         logFile,
       ),
     'Installing WordPress',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "WordPress end to end testing with Cypress.io",
   "repository": "https://github.com/bigbite/wp-cypress",
   "author": {

--- a/plugin/assets/disable-tooltips.js
+++ b/plugin/assets/disable-tooltips.js
@@ -6,6 +6,11 @@ jQuery(document).ready(() => {
   const nux = select('core/nux');
 
   if (!nux) {
+    // needed for WP version <=6.0
+    if (select('core/edit-post').isFeatureActive('welcomeGuide')) {
+      dispatch('core/edit-post').toggleFeature('welcomeGuide');
+    }
+
     return;
   }
 

--- a/plugin/assets/disable-tooltips.js
+++ b/plugin/assets/disable-tooltips.js
@@ -6,7 +6,7 @@ jQuery(document).ready(() => {
   const nux = select('core/nux');
 
   if (!nux) {
-    // needed for WP version <=6.0
+    // needed for some earlier versions of WP
     if (select('core/edit-post').isFeatureActive('welcomeGuide')) {
       dispatch('core/edit-post').toggleFeature('welcomeGuide');
     }

--- a/plugin/assets/disable-tooltips.js
+++ b/plugin/assets/disable-tooltips.js
@@ -6,10 +6,6 @@ jQuery(document).ready(() => {
   const nux = select('core/nux');
 
   if (!nux) {
-    if (select('core/edit-post').isFeatureActive('welcomeGuide')) {
-      dispatch('core/edit-post').toggleFeature('welcomeGuide');
-    }
-
     return;
   }
 

--- a/plugin/src/Fixtures/User.php
+++ b/plugin/src/Fixtures/User.php
@@ -11,6 +11,9 @@ class User extends Fixture {
 	 * @return array
 	 */
 	public function defaults(): array {
+		global $wpdb;
+		$user_preferences_meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+
 		return [
 			'user_pass'       => 'password',
 			'user_login'      => $this->faker->unique()->userName(),
@@ -23,7 +26,7 @@ class User extends Fixture {
 			'user_registered' => Utils\now(),
 			'role'            => 'administrator',
 			'meta_input' => [
-				'wp_persisted_preferences' => [
+				$user_preferences_meta_key => [
 					"core/edit-post" => [
 						"welcomeGuide" => false,
 					],

--- a/plugin/src/Fixtures/User.php
+++ b/plugin/src/Fixtures/User.php
@@ -22,6 +22,13 @@ class User extends Fixture {
 			'description'     => $this->faker->realText( 200 ),
 			'user_registered' => Utils\now(),
 			'role'            => 'administrator',
+			'meta_input' => [
+				'wp_persisted_preferences' => [
+					"core/edit-post" => [
+						"welcomeGuide" => false,
+					],
+				],
+			],
 		];
 	}
 

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -92,7 +92,10 @@ class Plugin {
 	}
 
 	public function initialize_admin_user_meta(): void {
-		update_user_meta(1, 'wp_persisted_preferences', [
+		global $wpdb;
+		$user_preferences_meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+
+		update_user_meta(1, $user_preferences_meta_key, [
 			"core/edit-post" => [
 				"welcomeGuide" => false,
 			],

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -101,10 +101,12 @@ class Plugin {
 		global $wpdb;
 		$user_preferences_meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
 
-		update_user_meta(1, $user_preferences_meta_key, [
-			"core/edit-post" => [
-				"welcomeGuide" => false,
-			],
-		]);
+		if ( !get_user_meta(1, $user_preferences_meta_key) ) {
+			update_user_meta(1, $user_preferences_meta_key, [
+				"core/edit-post" => [
+					"welcomeGuide" => false,
+				],
+			]);
+		}
 	}
 };

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -91,6 +91,12 @@ class Plugin {
 		WP_CLI::success( 'Current User set to ' . $args[0] );
 	}
 
+	/**
+	 * Sets default meta values on the root/admin user (this has to be done
+	 * separately from the other users)
+	 *
+	 * @return void
+	 */
 	public function initialize_admin_user_meta(): void {
 		global $wpdb;
 		$user_preferences_meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -9,6 +9,7 @@ use WP_Cypress\Seeder\SeedCommand;
 class Plugin {
 	public function __construct() {
 		add_action( 'init', [ $this, 'add_seed_command' ], 1 );
+		add_action( 'init', [ $this, 'initialize_admin_user_meta' ], 0 );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_assets' ], 1 );
 
 		$this->add_user_command();
@@ -88,5 +89,13 @@ class Plugin {
 
 		file_put_contents( $user_id_file, $user_id );
 		WP_CLI::success( 'Current User set to ' . $args[0] );
+	}
+
+	public function initialize_admin_user_meta(): void {
+		update_user_meta(1, 'wp_persisted_preferences', [
+			"core/edit-post" => [
+				"welcomeGuide" => false,
+			],
+		]);
 	}
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Link to previous PR: https://github.com/bigbite/wp-cypress/pull/124

## Description
In WP 6.2, the default WordPress 'welcome guide' modal is appearing within the Gutenberg editor which prevents test execution.  To fix this, I've updated the user meta for the admin to prevent this occuring.

## Change Log
Adds an action to the `init` hook which sets `wp_persisted_preferences` to:
```
[
  "core/edit-post" =>
  [
    "welcomeGuide" => false,
  ],
]
```
This means the Welcome Message modal will no longer appear in the Gutenberg editor.

Also fixes some formatting errors in lib/cli/commands/reset.js to fix a linting error. 
(Commit: https://github.com/bigbite/wp-cypress/pull/126/commits/ffa083e63a5a592f26a9b9181758a895cfbaf4e9)

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
