### PR TITLE
HOTFIX: Include the fetch pollyfill to prevent test fails if the cdn is down.

### DIFF
--- a/lib/cypress-support/hooks.js
+++ b/lib/cypress-support/hooks.js
@@ -1,15 +1,10 @@
 /* eslint-disable no-param-reassign */
-let fetchPolyfill;
+const fetchPolyfill =
+  '!function(e,n){"object"==typeof exports&&"undefined"!=typeof module?module.exports=n():"function"==typeof define&&define.amd?define(n):(e||self).unfetch=n()}(this,function(){return function(e,n){return n=n||{},new Promise(function(t,o){var r=new XMLHttpRequest,s=[],u={},i=function e(){return{ok:2==(r.status/100|0),statusText:r.statusText,status:r.status,url:r.responseURL,text:function(){return Promise.resolve(r.responseText)},json:function(){return Promise.resolve(r.responseText).then(JSON.parse)},blob:function(){return Promise.resolve(new Blob([r.response]))},clone:e,headers:{keys:function(){return s},entries:function(){return s.map(function(e){return[e,r.getResponseHeader(e)]})},get:function(e){return r.getResponseHeader(e)},has:function(e){return null!=r.getResponseHeader(e)}}}};for(var f in r.open(n.method||"get",e,!0),r.onload=function(){r.getAllResponseHeaders().toLowerCase().replace(/^(.+?):/gm,function(e,n){u[n]||s.push(u[n]=n)}),t(i())},r.onerror=o,r.withCredentials="include"==n.credentials,n.headers)r.setRequestHeader(f,n.headers[f]);r.send(n.body||null)})}})';
 
 Cypress.wp = {};
 
 before(() => {
-  const polyfillUrl = 'https://unpkg.com/unfetch/dist/unfetch.umd.js';
-
-  cy.request(polyfillUrl).then((response) => {
-    fetchPolyfill = response.body;
-  });
-
   const installedWordpressVersions = Cypress.config('wordpressVersions');
 
   if (installedWordpressVersions.length === 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.11.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5197,6 +5197,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5197,11 +5197,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "unfetch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
-      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigbite/wp-cypress",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "WordPress end to end testing with Cypress.io",
   "repository": "https://github.com/bigbite/wp-cypress",
   "author": {
@@ -59,6 +59,7 @@
     "prettier": "^2.5.1",
     "pretty-error": "^4.0.0",
     "semver": "^7.3.7",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.8.5",
+    "unfetch": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "prettier": "^2.5.1",
     "pretty-error": "^4.0.0",
     "semver": "^7.3.7",
-    "shelljs": "^0.8.5",
-    "unfetch": "^5.0.0"
+    "shelljs": "^0.8.5"
   }
 }


### PR DESCRIPTION
## Description
Fixes: #132 

Currently the fetch pollyfill is brought in over a CDN and is currently down causing tests to fail instantly.

The unreleased 1.0.0 version of wp-cypress includes the polyfill inside the project. This PR will bring this change into a released version.

I've tested locally using yalc and this fix resolves the issue.

## Change Log
* Include fetch polyfill directly into the codebase.

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] Meets provided linting standards.
