### PR TITLE
string version denotes subdir, build provides xdebug

### DIFF
--- a/config/xdebug.ini
+++ b/config/xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug.so
+serverName=wp-cypress
+xdebug.client_host=host.docker.internal
+xdebug.mode=debug
+xdebug.idekey=PhpStorm

--- a/lib/modules/createConfig.js
+++ b/lib/modules/createConfig.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require, import/no-dynamic-require */
 const fs = require('fs-extra');
+const { execSync } = require('child_process');
 const path = require('path');
 const glob = require('glob');
 const { get, defaults } = require('lodash');
@@ -135,6 +136,23 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
   const version = Array.isArray(config.version) ? config.version : [config.version];
   const validVersions = await getValidVersions(version);
 
+  const composerWordpress = path.resolve( CWD, version[0] );
+  let usableVersions;
+  if ( fs.existsSync( composerWordpress ) ) {
+    if ( ! hasVolumeSupport ) {
+      const vendorSync = `${packageDir}/wordpress`;
+      if ( !fs.existsSync( vendorSync ) ) {
+        fs.mkdirSync( vendorSync );
+      }
+      execSync(`rsync -r --delete ${composerWordpress}/ ${vendorSync}/`);
+    } else {
+      volumes.push( `${composerWordpress}:/var/www/wordpress` );
+    }
+    usableVersions = [ 'wordpress' ];
+  } else {
+    usableVersions = validVersions;
+  }
+
   await renderTemplate(
     `${packageDir}/lib/templates/docker-compose.ejs`,
     `${packageDir}/docker-compose.yml`,
@@ -142,6 +160,7 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
       port: config.port || 80,
       dbPort: config.dbPort || 3306,
       volumes: hasVolumeSupport ? volumes : false,
+      env: config.env || {},
     },
   );
 
@@ -155,18 +174,19 @@ const createConfig = async (packageDir, hasVolumeSupport = true) => {
 
   await renderTemplate(`${packageDir}/lib/templates/dockerfile.ejs`, `${packageDir}/Dockerfile`, {
     isWpContent: config.wpContent,
-    versions: validVersions,
+    versions: usableVersions,
     vip: config.muPlugins ? config.muPlugins.vip : false,
     phpVersion: config.phpVersion || 7.4,
     phpMemoryLimit: config.phpMemoryLimit || '128M',
     htaccessFile,
     workingDir,
+    volumes,
   });
 
   const wpCypressConfig = {
     ...config,
     version,
-    validVersions,
+    validVersions: usableVersions,
     volumes,
     activePlugins,
     activeTheme,

--- a/lib/templates/docker-compose.ejs
+++ b/lib/templates/docker-compose.ejs
@@ -4,6 +4,9 @@ services:
     depends_on:
       - db
     build: .
+    environment:
+      CYPRESS_TEST: 1 <% Object.entries( env ).forEach(([n,v]) => { %>
+      <%= n %> : <%= v %> <% }); %>
     ports:
       - <%= port %>:80
     <% if (volumes) { %>volumes: <% volumes.forEach((volume) => { %>
@@ -19,3 +22,7 @@ services:
       - db:/var/lib/mysql
 volumes:
   db: {}
+
+networks:
+  bridge0:
+

--- a/lib/templates/dockerfile.ejs
+++ b/lib/templates/dockerfile.ejs
@@ -1,8 +1,11 @@
 FROM php:<%= phpVersion %>-apache
 
-RUN apt-get update && apt-get install -y wget libpng-dev libjpeg-dev gnupg default-mysql-client nano less unzip && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y wget rsync libpng-dev libjpeg-dev gnupg default-mysql-client nano less unzip && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd \
-	&& docker-php-ext-install gd mysqli
+	&& docker-php-ext-install gd mysqli \
+	&& pecl install xdebug
+
+COPY config/xdebug.ini /usr/local/etc/php/conf.d
 
 RUN a2enmod rewrite
 
@@ -22,7 +25,9 @@ RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
   && php composer-setup.php --version=1.10.16 \
   && mv composer.phar /bin/composer
 
-<% versions.forEach((version) => { %>
+<% versions.forEach((version) => {
+     if ( version.match(/(\d+.?)+/) ) {
+%>
 RUN curl https://wordpress.org/wordpress-<%= version %>.tar.gz > wordpress-<%= version %>.tar.gz && \
   mkdir -p <%= workingDir %>/<%= version %> && \
   tar -xzf wordpress-<%= version %>.tar.gz -C <%= workingDir %>/<%= version %> && \
@@ -30,6 +35,10 @@ RUN curl https://wordpress.org/wordpress-<%= version %>.tar.gz > wordpress-<%= v
   rm -rf <%= workingDir %>/<%= version %>/wordpress && \
   chown -R www-data:www-data <%= workingDir %>/<%= version %><% if (isWpContent) { %> && \<% } else { %>;<% } %>
   <% if (isWpContent) { %>rm -rf <%= workingDir %>/<%= version %>/wp-content;<% } %>
+<% } else if ( ! volumes.find( (v) => v.includes('/var/www/wordpress') ) ) { %>
+ADD <%= version %> /var/www/wordpress
+RUN chown -R www-data:www-data /var/www/wordpress
+  <% } %>
 <% }); %>
 
 <% if (vip) { %>


### PR DESCRIPTION
A version that specifies a directory is taken to contain a wordpress install, which is mounted in the VM as a volume or rsynced into the wp-cypress tree and COPY-ed in from there.

Xdebug is installed during VM build and an xdebug.ini is provided.

Environment strings can be specified in cypress.config.js

## Change Log

- config/xdebug.ini : host.docker.internal, PhpStorm and serverName=wp-cypress
- lib/modules/createConfig.js : sync and option discovery code
- lib/templates/docker-compose.ejs : volume mount, network (bridge0) and env strings
- lib/templates/dockerfile.ejs : install rsync and copy subdir if volumes not supported

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
